### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "bugs": {
     "url": "https://github.com/Brightspace/frau-superagent-xsrf-token/issues"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "dependencies": {
     "frau-xsrf-token": "^3"
   },


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564